### PR TITLE
Replaced CoP GForm link with ESCS forum and newsletter links

### DIFF
--- a/index.md
+++ b/index.md
@@ -76,7 +76,7 @@ __:bust_in_silhouette: We are recruiting!__ Interested in joining the Green Algo
 __:tada: The Green Algorithms project has won the [2024 Susannah Boddie Impact of the Year Award](https://www.hdruk.ac.uk/news/winners-announced-2024-hdr-uk-annual-prizes/){:target="_blank"} at the Health Data Research UK annual conference!__ “The panel applauded the work’s clear impact on policy in a short time frame. The panel were impressed by the direct and tangible environmental impacts of these efforts, and recognised the pioneering role of this collaborative effort in raising awareness and providing tools for carbon footprint estimation in computational research.”
 {: .notice--success}
 
-__:mega: We are starting a Community of Practice around Environmentally Sustainable Computational Science!__ Interested in joining it or just seeing how this goes? __Just fill in [this form](https://forms.gle/pftpt2YEFsQqayut6).__
+__:mega: We are starting a Community of Practice around Environmentally Sustainable Computational Science!__ Join the [online forum](https://forum.escs-community.org/) for discussions around green computing, and subscribe to the [newsletter](https://zcmp.eu/oRye) where we send a monthly digest of the latest news and developments in the sustainable computing space.
 {: .notice--info}
 
 The Green Algorithms project aims at promoting more environmentally sustainable computational science. It regroups calculators that researchers can use to estimate the carbon footprint of their projects, tips on how to be more environmentally friendly, training material, past talks etc.


### PR DESCRIPTION
Removed Google Form from Community of Practice section and added links to forum and newsletter